### PR TITLE
Include own board in room

### DIFF
--- a/client/src/components/Ojyks.jsx
+++ b/client/src/components/Ojyks.jsx
@@ -49,7 +49,6 @@ export default class Ojyks extends Component {
                 console.log("game state", data);
 
                 const player = payload.players.find(p => p.name === this.context.username);
-                const others = payload.players.filter(p => p.name !== this.context.username);
                 //const currentPlayer = payload.players.find(p => p.name === payload.currentPlayer);
 
                 this.setState({
@@ -59,7 +58,7 @@ export default class Ojyks extends Component {
                     boardCards: player.cards,
                     state: player.state,
 
-                    players: others
+                    players: payload.players
                     //currentPlayerCards: currentPlayer.cards
                 });
 


### PR DESCRIPTION
# Why?

Current it was not clear after which player the turn is taken, and which player follows of my turn. Therefore, tactical playing was not really possible.

# What?

- include own deck in the room view to see after and before which player the turn takes place