### PR TITLE
Refactor card component: simplifying by not defining as function inst…

### DIFF
--- a/client/src/components/Board.jsx
+++ b/client/src/components/Board.jsx
@@ -9,7 +9,7 @@ export default function Board(props) {
         <div className="board2">
             {props.cards.map((card, i) => 
                 <div className="board-card-place" key={i}>
-                    {card && <Card card={card} cell={i} handleClick={props.handleClick} source={"board"}/>}
+                    {card && <Card card={card} cell={i} handleClick={props.handleClick} source="board"/>}
                 </div>
             )}
         </div>

--- a/client/src/components/Card.jsx
+++ b/client/src/components/Card.jsx
@@ -6,12 +6,12 @@ Card.propTypes = {
     card: PropTypes.object.isRequired,
     cell: PropTypes.number.isRequired,
     source: PropTypes.string.isRequired,
-    handleClick: PropTypes.func.isRequired
+    handleClick: PropTypes.func
 };
 
 export default function Card({card, cell, source, handleClick}) {
     return (
-        <div className="card2" onClick={() => handleClick({ source: source, cell: cell })}>
+        <div className="card2" onClick={() => handleClick && handleClick({ source: source, cell: cell })}>
             <div className={getClassName(card)} >
                 <div className="card-number">
                     {card.faceDown ?

--- a/client/src/components/Card.jsx
+++ b/client/src/components/Card.jsx
@@ -1,47 +1,42 @@
-import React, { Component } from 'react'
-import './Card.css'
-// todo card index
-// is visible 
-// value
-export default class Card extends Component {
-    constructor(props) {
-        super(props);
+import React from 'react';
+import PropTypes from 'prop-types';
+import './Card.css';
 
-        this.getClassName = this.getClassName.bind(this);
-    }
+Card.propTypes = {
+    card: PropTypes.object.isRequired,
+    cell: PropTypes.number.isRequired,
+    source: PropTypes.string.isRequired,
+    handleClick: PropTypes.func.isRequired
+};
 
-    getClassName() {
-        const { card } = this.props;
-        if (card.faceDown) {
-            return "card-facedown";
-        } else {
-            if (card.value < 0) {
-                return "card-violet";
-            } else if (card.value === 0) {
-                return "card-blue";
-            } else if (card.value < 5) {
-                return "card-green";
-            } else if (card.value < 9) {
-                return "card-yellow";
-            } else {
-                return "card-red";
-            }
-        }
-    }
-
-    render() {
-        const { card, cell } = this.props;
-        return (
-            <div className="card2" onClick={() => this.props.handleClick({ source: this.props.source, cell: cell })}>
-                <div className={this.getClassName()} >
-                    <div className="card-number">
-                        {card.faceDown ?
-                            "" :
-                            card.value
-                        }
-                    </div>
+export default function Card({card, cell, source, handleClick}) {
+    return (
+        <div className="card2" onClick={() => handleClick({ source: source, cell: cell })}>
+            <div className={getClassName(card)} >
+                <div className="card-number">
+                    {card.faceDown ?
+                        "" :
+                        card.value
+                    }
                 </div>
             </div>
-        )
+        </div>
+    );
+}
+
+function getClassName(card) {
+    if (card.faceDown) {
+        return "card-facedown";
+    } else {
+        if (card.value < 0) {
+            return "card-violet";
+        } else if (card.value === 0) {
+            return "card-blue";
+        } else if (card.value < 5) {
+            return "card-green";
+        } else if (card.value < 9) {
+            return "card-yellow";
+        }
+        return "card-red";
     }
 }

--- a/client/src/components/DiscardPile.jsx
+++ b/client/src/components/DiscardPile.jsx
@@ -7,7 +7,7 @@ export default function DiscardPile(props) {
         // only activate function on discard pile if no card exists
         <div className="discard-pile" onClick={props.cards.length === 0 ? () => props.handleClick({source: "discard"}) : () => {}}>
             {props.cards.length > 0 && (
-                <Card card={props.cards[0]} cell={-1} handleClick={props.handleClick} source={"discard"}/>
+                <Card card={props.cards[0]} cell={-1} handleClick={props.handleClick} source="discard"/>
             )}
         </div>
     )

--- a/client/src/components/DrawPile.jsx
+++ b/client/src/components/DrawPile.jsx
@@ -6,7 +6,7 @@ export default function DrawPile(props) {
     return (
         <div className="draw-pile">
             {props.cards.length > 0 && (
-                <Card card={props.cards[0]} cell={-1} handleClick={props.handleClick} source={"draw"}/>
+                <Card card={props.cards[0]} cell={-1} handleClick={props.handleClick} source="draw"/>
             )}
         </div>
     )

--- a/client/src/components/StateDisplay.jsx
+++ b/client/src/components/StateDisplay.jsx
@@ -23,7 +23,7 @@ function toReadableText(state) {
         case 'ready':
             const otherPlayer = getActivePlayer(state);
             if (otherPlayer) {
-                return `It is ${otherPlayer.name}\'s turn!`;
+                return `It is ${otherPlayer.name}'s turn!`;
             }
             return 'It is another players turn!';
         case 'end':


### PR DESCRIPTION
# Why?

Just an example to simplify this component and make it easier to manage when working in a team.

# What?

- Define component as a `function` instead of as a `class`, so that binding and indirect access to `this.props` is not needed
- Use props-unpacking in function signature
- Define `PropTypes`:
  - Check at runtime that all required parameters are specified and are of the right type
  - Indicate which type each parameter has to be