### PR TITLE
Send chat-message on enter key for convenience

### DIFF
--- a/client/src/components/Board.jsx
+++ b/client/src/components/Board.jsx
@@ -5,7 +5,6 @@ import './Board.css'
 
 export default function Board(props) {
     // click card tu turn, to swap
-    console.log(props.handleClick);
     return (
         <div className="board2">
             {props.cards.map((card, i) => 

--- a/client/src/components/Lobby/Lobby.jsx
+++ b/client/src/components/Lobby/Lobby.jsx
@@ -104,7 +104,18 @@ export default class Lobby extends Component {
 
                     <div className="col m6 s12">
                         <div className="input-field">
-                            <input type="text" name="message" id="message" value={this.state.message} onChange={this.handleChange} />
+                            <input 
+                                type="text"
+                                name="message"
+                                id="message"
+                                value={this.state.message}
+                                onChange={this.handleChange}
+                                onKeyDown={(e) => {
+                                    if (e.key === 'Enter') {
+                                        this.handleSend(e);
+                                    }
+                                }}
+                            />
                             <label htmlFor="message">Nachricht:</label>
                             <button className="btn" onClick={this.handleSend}>Senden</button>
                         </div>

--- a/client/src/components/Ojyks.jsx
+++ b/client/src/components/Ojyks.jsx
@@ -208,7 +208,18 @@ export default class Ojyks extends Component {
                 </div>
                 <div className="chat">
                     <div className="input-field">
-                        <input type="text" name="message" id="message" value={this.state.message} onChange={this.handleChange} />
+                        <input 
+                            type="text"
+                            name="message"
+                            id="message"
+                            value={this.state.message}
+                            onChange={this.handleChange}
+                            onKeyDown={(e) => {
+                                if (e.key === 'Enter') {
+                                    this.handleSend(e);
+                                }
+                            }} 
+                        />
                         <label htmlFor="message">Nachricht:</label>
                         <button className="btn" onClick={this.handleSend}>Senden</button>
                     </div>


### PR DESCRIPTION
# Why?

It's would be a bit more convenient to send the message straight after hitting the ENTER key. Currently multi-line did not work anyways, so ENTER simply did not do anything yet.

# What?

Listen on `onKeyDown` for the `<input />` field, to execute `handleSend` if the ENTER key was pressed