### PR TITLE
Refactor chat: extract component

### DIFF
--- a/client/src/components/Chat.jsx
+++ b/client/src/components/Chat.jsx
@@ -1,0 +1,61 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+export default class Chat extends Component {
+    handleSend = (e) => {
+        e.preventDefault();
+        const { context, lobby } = this.props;
+        const message = this.messageInput.value.trim();
+
+        if (isBlank(message)) {
+            return;
+        }
+
+        const payload = {
+            player: context.username,
+            lobby,
+            message
+        };
+        context.send({ type: 'request', action: 'lobby-message', payload });
+        context.addMessage(payload);
+        this.messageInput.value = '';
+    }
+
+    render() {
+        const { context } = this.props;
+        return (
+            <>
+                <div className="input-field">
+                    <input 
+                        type="text"
+                        name="messageInput"
+                        id="messageInput"
+                        ref={el => this.messageInput = el}
+                        onKeyDown={(e) => {
+                            if (e.key === 'Enter') {
+                                this.handleSend(e);
+                            }
+                        }}
+                    />
+                    <label htmlFor="messageInput">Nachricht:</label>
+                    <button className="btn" onClick={this.handleSend}>Senden</button>
+                </div>
+    
+                <ul>
+                    {context.chat.map((m, i) => (
+                        <li key={i}>{m.player}: {m.message}</li>
+                    ))}
+                </ul>
+            </>
+        );
+    }
+}
+
+Chat.propTypes = {
+    context: PropTypes.object.isRequired,
+    lobby: PropTypes.string.isRequired
+};
+
+function isBlank(str) {
+    return !str || str.length === 0 || str.trim().length === 0;
+}

--- a/client/src/components/Lobby/Lobby.jsx
+++ b/client/src/components/Lobby/Lobby.jsx
@@ -1,4 +1,7 @@
-import React, { Component } from 'react'
+import React, { Component } from 'react';
+
+import Chat from '../Chat';
+
 import { UserContext } from '../../context/user-context'
 
 // displays all users
@@ -17,23 +20,7 @@ export default class Lobby extends Component {
         }
 
         this.handleMessage = this.handleMessage.bind(this);
-        this.handleChange = this.handleChange.bind(this);
-        this.handleSend = this.handleSend.bind(this);
-
         this.handleStart = this.handleStart.bind(this);
-    }
-
-    handleChange(e) {
-        this.setState({ [e.target.name]: e.target.value });
-    }
-
-    handleSend(e) {
-        e.preventDefault();
-        const message = { player: this.context.username, lobby: this.props.match.params.name, message: this.state.message };
-        this.context.send({ type: 'request', action: 'lobby-message', payload: message });
-        this.context.addMessage(message);
-
-        this.setState({ message: "" });
     }
 
     handleMessage(data) {
@@ -119,28 +106,7 @@ export default class Lobby extends Component {
                     </div>
 
                     <div className="col m6 s12">
-                        <div className="input-field">
-                            <input 
-                                type="text"
-                                name="message"
-                                id="message"
-                                value={this.state.message}
-                                onChange={this.handleChange}
-                                onKeyDown={(e) => {
-                                    if (e.key === 'Enter') {
-                                        this.handleSend(e);
-                                    }
-                                }}
-                            />
-                            <label htmlFor="message">Nachricht:</label>
-                            <button className="btn" onClick={this.handleSend}>Senden</button>
-                        </div>
-
-                        <ul>
-                            {this.context.chat.map((m, i) => (
-                                <li key={i}>{m.player}: {m.message}</li>
-                            ))}
-                        </ul>
+                        <Chat context={this.context} lobby={this.props.match.params.name} />
                     </div>
 
                 </div>

--- a/client/src/components/Ojyks.jsx
+++ b/client/src/components/Ojyks.jsx
@@ -1,7 +1,8 @@
-import React, { Component } from 'react'
+import React, { Component } from 'react';
 
+import Chat from './Chat';
 import CardDeck from './CardDeck';
-import DrawPile from './DrawPile'
+import DrawPile from './DrawPile';
 import DiscardPile from './DiscardPile';
 import StateDisplay from './StateDisplay';
 
@@ -35,21 +36,6 @@ export default class Ojyks extends Component {
 
         this.executeTurn = this.executeTurn.bind(this);
         this.handleMessage = this.handleMessage.bind(this);
-        this.handleSend = this.handleSend.bind(this);
-        this.handleChange = this.handleChange.bind(this);
-    }
-
-    handleChange(e) {
-        this.setState({ [e.target.name]: e.target.value });
-    }
-
-    handleSend(e) {
-        e.preventDefault();
-        const message = { player: this.context.username, lobby: this.props.match.params.name, message: this.state.message };
-        this.context.send({ type: 'request', action: 'lobby-message', payload: message });
-        this.context.addMessage(message);
-
-        this.setState({ message: "" });
     }
 
     handleMessage(data) {
@@ -218,30 +204,7 @@ export default class Ojyks extends Component {
                 </div>
                 <div className="row">
                     <div className="col s12">
-                        <div>
-                            <div className="input-field">
-                                <input 
-                                    type="text"
-                                    name="message"
-                                    id="message"
-                                    value={this.state.message}
-                                    onChange={this.handleChange}
-                                    onKeyDown={(e) => {
-                                        if (e.key === 'Enter') {
-                                            this.handleSend(e);
-                                        }
-                                    }} 
-                                />
-                                <label htmlFor="message">Nachricht:</label>
-                                <button className="btn" onClick={this.handleSend}>Senden</button>
-                            </div>
-
-                            <ul>
-                                {this.context.chat.map((m, i) => (
-                                    <li key={i}>{m.player}: {m.message}</li>
-                                ))}
-                            </ul>
-                        </div>
+                        <Chat context={this.context} lobby={this.props.match.params.name} />
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
### Why?

The chat component was used in two places in exactly the same way

### What?

- Refactor chat: extract component
- Simplify component
- Make the used `<input />` element **uncontrolled**
- Fix minor bug: prevent sending of empty/blank messages and remove whitespace